### PR TITLE
build: Pull Requestマージ時に動くワークフローを追加

### DIFF
--- a/.github/workflows/pr-merge-head.yaml
+++ b/.github/workflows/pr-merge-head.yaml
@@ -1,0 +1,24 @@
+name: pr-merge-head
+
+on:
+  pull_request:
+    branches:
+      - "pr/**"
+    types: [closed]
+
+jobs:
+  pr-merge-head:
+    if: github.event.pull_request.merged == true
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          echo "github.head_ref"
+          echo ${{ github.head_ref }}
+          echo "github.base_ref"
+          echo ${{ github.base_ref }}
+          echo "github.ref"
+          echo ${{ github.ref }}
+          echo "github.ref_name"
+          echo ${{ github.ref_name }}

--- a/.github/workflows/pr-merge-main.yaml
+++ b/.github/workflows/pr-merge-main.yaml
@@ -1,0 +1,24 @@
+name: pr-merge-main
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    types: [closed]
+
+jobs:
+  pr-merge-main:
+    if: github.event.pull_request.merged == true
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          echo "github.head_ref"
+          echo ${{ github.head_ref }}
+          echo "github.base_ref"
+          echo ${{ github.base_ref }}
+          echo "github.ref"
+          echo ${{ github.ref }}
+          echo "github.ref_name"
+          echo ${{ github.ref_name }}


### PR DESCRIPTION
`types: [closed]` のとき `branches` の指定の違いを検証
